### PR TITLE
Dont throw System.Exception

### DIFF
--- a/jose-jwt/util/Base64Url.cs
+++ b/jose-jwt/util/Base64Url.cs
@@ -23,7 +23,7 @@ namespace Jose
                 case 0: break; // No pad chars in this case
                 case 2: output += "=="; break; // Two pad chars
                 case 3: output += "="; break; // One pad char
-                default: throw new System.Exception("Illegal base64url string!");
+                default: throw new System.ArgumentOutOfRangeException("input","Illegal base64url string!");
             }
             var converted = Convert.FromBase64String(output); // Standard base64 decoder
             return converted;


### PR DESCRIPTION
System.Exception is too vague to have to catch.

Proposed change updates it to ArgumentOutOfRangeException, which fits better. If its not a base64 encoding, its out of the acceptable range the string is allowed to have.