### PR TITLE
Add support for specifying a custom IKeyManagement implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,24 @@ MyDomainObject obj=Jose.JWT.Decode<MyDomainObject>(token,secretKey); //will invo
 string data=Jose.JWT.Encode(obj,secrectKey,JwsAlgorithm.HS256); //for object argument configured IJsonMapper will be invoked to serialize object to json string before encoding
 ```
 
+## Settings
+Settings can be configured either globally or on a per-call basis using a `JWTSettings` object.  The `JWT.DefaultSettings` object can be modified to change global settings, or a `JWTSettings` instance can be passed to any public method on `JWT` to override the global settings for that method call.
+
+### Example of JWTSettings
+
+```C#
+// global setting
+Jose.JWT.DefaultSettings.JsonMapper = new Jose.NewtonsoftMapper();
+
+
+Jose.JWTSettings settings = new Jose.JWTSettings();
+settings.JsonMapper = new Jose.JSSerializerMapper();
+
+// override global settings for this call
+Jose.JWT.Decode(token, secretKey, settings: settings);
+
+```
+
 ### Customizing json <-> object parsing & mapping
 The library provides simple `Jose.IJsonMapper` interface to plug any json processing library or customize default behavior. The only requirement for mapping implementations
 is ability to correctly serialize/parse `IDictionary<string,object>` type.
@@ -587,7 +605,7 @@ public class NewtonsoftMapper : IJsonMapper
     }
 }
 
-Jose.JWT.JsonMapper = new NewtonsoftMapper();
+Jose.JWT.DefaultSettings.JsonMapper = new NewtonsoftMapper();
 ```
 
 #### Example of ServiceStack mapper
@@ -605,7 +623,31 @@ public class ServiceStackMapper : IJsonMapper
     }
 }
 
-Jose.JWT.JsonMapper = new ServiceStackMapper();
+Jose.JWT.DefaultSettings.JsonMapper = new ServiceStackMapper();
+```
+
+### Customizing algorithm implementations
+The default implementations of any of the signing, encryption, key management, or compression algorithms can be overridden.
+
+#### Example of custom algorithm implementation
+```C#
+public class CustomKeyManagement : IKeyManagement
+{
+    public byte[] Unwrap(byte[] encryptedCek, object key, int cekSizeBits, IDictionary<string, object> header)
+    {
+        // implement custom key unwrapping (e.g. using a key management service)
+    }
+
+    public byte[][] WrapNewKey(int cekSizeBits, object key, IDictionary<string, object> header)
+    {
+        // implement custom key wrapping (e.g. using a key management service)
+    }
+}
+
+...
+
+// set default RSA-OAEP key management to use custom implementation
+Jose.JWT.DefaultSettings.KeyAlgorithms[JweAlgorithm.RSA_OAEP] = new CustomKeyManagement();
 ```
 
 ## More examples

--- a/UnitTests/TestSuite.cs
+++ b/UnitTests/TestSuite.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Jose;
 using Security.Cryptography;
 using Xunit;
+using Jose.jwe;
 
 namespace UnitTests
 {
@@ -2315,6 +2316,228 @@ namespace UnitTests
                 Console.WriteLine(e);
             }
         }
+        
+        [Fact]
+        public void Encode_IJsonMapper_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJsonMapper jsMapper = new MockJsonMapper();
+            settings.JsonMapper = jsMapper;
+            var payload = new
+            {
+                hello = "world"
+            };
+            //when
+            string token = Jose.JWT.Encode(payload, null, JwsAlgorithm.none, settings: settings);
+
+            Console.Out.WriteLine("Plaintext:" + token);
+
+            //then
+            Assert.Equal(token, "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJoZWxsbyI6IndvcmxkIn0.");
+            Assert.True(jsMapper.SerializeCalled);
+        }
+
+        [Fact]
+        public void Decode_IJsonMapper_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJsonMapper jsMapper = new MockJsonMapper();
+            settings.JsonMapper = jsMapper;
+            string token = "eyJhbGciOiJub25lIn0.eyJoZWxsbyI6ICJ3b3JsZCJ9.";
+
+            //when
+            var test = Jose.JWT.Decode<IDictionary<string, object>>(token, settings: settings);
+
+            //then
+            Assert.Equal(test, new Dictionary<string, object> { { "hello", "world" } });
+            Assert.True(jsMapper.ParseCalled);
+        }
+
+        [Fact]
+        public void Encode_IJwsAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJwsAlgorithm jwsAlg = new MockJwsAlgorithm();
+            settings.HashAlgorithms[JwsAlgorithm.none] = jwsAlg;
+            var payload = new
+            {
+                hello = "world"
+            };
+
+            //when
+            string token = Jose.JWT.Encode(payload, null, JwsAlgorithm.none, settings: settings);
+
+            Console.Out.WriteLine("Plaintext:" + token);
+
+            //then
+            Assert.Equal(token, "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJoZWxsbyI6IndvcmxkIn0.");
+            Assert.True(jwsAlg.SignCalled);
+        }
+
+        [Fact]
+        public void Decode_IJwsAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJwsAlgorithm jwsAlg = new MockJwsAlgorithm();
+            settings.HashAlgorithms[JwsAlgorithm.none] = jwsAlg;
+            string token = "eyJhbGciOiJub25lIn0.eyJoZWxsbyI6ICJ3b3JsZCJ9.";
+
+            //when
+            var test = Jose.JWT.Decode<IDictionary<string, object>>(token, settings: settings);
+
+            //then
+            Assert.Equal(test, new Dictionary<string, object> { { "hello", "world" } });
+            Assert.True(jwsAlg.VerifyCalled);
+        }
+
+        [Fact]
+        public void Encode_IJweAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJweAlgorithm encAlg = new MockJweAlgorithm(128);
+            settings.EncAlgorithms[JweEncryption.A128GCM] = encAlg;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, aes128Key, JweAlgorithm.DIR, JweEncryption.A128GCM, settings: settings);
+
+            //then
+            Console.Out.WriteLine("DIR_A128GCM = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 0); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[3].Length, 262); //cipher text size
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, aes128Key), json);
+            Assert.True(encAlg.EncryptCalled);
+        }
+
+        [Fact]
+        public void Decode_IJweAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJweAlgorithm encAlg = new MockJweAlgorithm(128);
+            settings.EncAlgorithms[JweEncryption.A128GCM] = encAlg;
+            string token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..yVi-LdQQngN0C5WS.1McwSmhZzAtmmLp9y-OdnJwaJFo1nj_4ashmzl2LhubGf0Jl1OTEVJzsHZb7bkup7cGTkuxh6Vfv10ljHsjWf_URXoxP3stQqQeViVcuPV0y2Q_WHYzTNGZpmHGe-hM6gjDhyZyvu3yeXGFSvfPQmp9pWVOgDjI4RC0MQ83rzzn-rRdnZkznWjbmOPxwPrR72Qng0BISsEwbkPn4oO8-vlHkVmPpuDTaYzCT2ZR5K9JnIU8d8QdxEAGb7-s8GEJ1yqtd_w._umbK59DAKA3O89h15VoKQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, aes128Key, settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392548520,""sub"":""alice"",""nbf"":1392547920,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""0e659a67-1cd3-438b-8888-217e72951ec9"",""iat"":1392547920}");
+            Assert.True(encAlg.DecryptCalled);
+        }
+
+        [Fact]
+        public void Encode_IKeyManagement_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockKeyManagement keyMgmt = new MockKeyManagement();
+            settings.KeyAlgorithms[JweAlgorithm.DIR] = keyMgmt;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, aes128Key, JweAlgorithm.DIR, JweEncryption.A128GCM, settings: settings);
+
+            //then
+            Console.Out.WriteLine("DIR_A128GCM = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 0); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[3].Length, 262); //cipher text size
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, aes128Key), json);
+
+            Assert.True(keyMgmt.WrapCalled);
+        }
+
+        [Fact]
+        public void Decode_IKeyManagement_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockKeyManagement keyMgmt = new MockKeyManagement();
+            settings.KeyAlgorithms[JweAlgorithm.DIR] = keyMgmt;
+            string token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..yVi-LdQQngN0C5WS.1McwSmhZzAtmmLp9y-OdnJwaJFo1nj_4ashmzl2LhubGf0Jl1OTEVJzsHZb7bkup7cGTkuxh6Vfv10ljHsjWf_URXoxP3stQqQeViVcuPV0y2Q_WHYzTNGZpmHGe-hM6gjDhyZyvu3yeXGFSvfPQmp9pWVOgDjI4RC0MQ83rzzn-rRdnZkznWjbmOPxwPrR72Qng0BISsEwbkPn4oO8-vlHkVmPpuDTaYzCT2ZR5K9JnIU8d8QdxEAGb7-s8GEJ1yqtd_w._umbK59DAKA3O89h15VoKQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, aes128Key, settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392548520,""sub"":""alice"",""nbf"":1392547920,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""0e659a67-1cd3-438b-8888-217e72951ec9"",""iat"":1392547920}");
+            Assert.True(keyMgmt.UnwrapCalled);
+        }
+
+        [Fact]
+        public void Encode_ICompression_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockCompression compress = new MockCompression();
+            settings.CompressionAlgorithms[JweCompression.DEF] = compress;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, PubKey(), JweAlgorithm.RSA_OAEP, JweEncryption.A256GCM, JweCompression.DEF, settings: settings);
+
+            //then
+            Console.Out.WriteLine("RSA-OAEP_A256GCM-DEFLATE = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00iLCJ6aXAiOiJERUYifQ"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 342); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, PrivKey()), json);
+
+            Assert.True(compress.CompressCalled);
+        }
+
+        [Fact]
+        public void Decode_ICompression_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockCompression compress = new MockCompression();
+            settings.CompressionAlgorithms[JweCompression.DEF] = compress;
+            string token = "eyJhbGciOiJSU0EtT0FFUCIsInppcCI6IkRFRiIsImVuYyI6IkExMjhDQkMtSFMyNTYifQ.nXSS9jDwE0dXkcGI7UquZBhn2nsB2P8u-YSWEuTAgEeuV54qNU4SlE76bToI1z4LUuABHmZOv9S24xkF45b7Mrap_Fu4JXH8euXrQgKQb9o_HL5FvE8m4zk5Ow13MKGPvHvWKOaNEBFriwYIfPi6QBYrpuqn0BaANc_aMyInV0Fn7e8EAgVmvoagmy7Hxic2sPUeLEIlRCDSGa82mpiGusjo7VMJxymkhnMdKufpGPh4wod7pvgb-jDWasUHpsUkHqSKZxlrDQxcy1-Pu1G37TAnImlWPa9NU7500IXc-W07IJccXhR3qhA5QaIyBbmHY0j1Dn3808oSFOYSF85A9w.uwbZhK-8iNzcjvKRb1a2Ig.jxj1GfH9Ndu1y0b7NRz_yfmjrvX2rXQczyK9ZJGWTWfeNPGR_PZdJmddiam15Qtz7R-pzIeyR4_qQoMzOISkq6fDEvEWVZdHnnTUHQzCoGX1dZoG9jXEwfAk2G1vXYT2vynEQZ72xk0V_OBtKhpIAUEFsXwCUeLAAgjFNY4OGWZl_Kmv9RTGhnePZfVbrbwg.WuV64jlV03OZm99qHMP9wQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, PrivKey(), settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392963710,""sub"":""alice"",""nbf"":1392963110,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""9fa7a38a-28fd-421c-825c-8fab3bbf3fb4"",""iat"":1392963110}");
+            Assert.True(compress.DecompressCalled);
+        }
 
         #region test utils
 
@@ -2402,5 +2625,100 @@ namespace UnitTests
 
         #endregion
     }
+    
+#region mocks
 
+    class MockJsonMapper : JSSerializerMapper, IJsonMapper
+    {
+        public bool SerializeCalled { get; set; }
+        public bool ParseCalled { get; set; }
+
+        public new string Serialize(object obj)
+        {
+            SerializeCalled = true;
+            return base.Serialize(obj);
+        }
+
+        public new T Parse<T>(string json)
+        {
+            ParseCalled = true;
+            return base.Parse<T>(json);
+        }
+    }
+
+    class MockJwsAlgorithm : Plaintext, IJwsAlgorithm
+    {
+        public bool SignCalled { get; set; }
+        public bool VerifyCalled { get; set; }
+
+        public new byte[] Sign(byte[] securedInput, object key)
+        {
+            SignCalled = true;
+            return base.Sign(securedInput, key);
+        }
+
+        public new bool Verify(byte[] signature, byte[] securedInput, object key)
+        {
+            VerifyCalled = true;
+            return base.Verify(signature, securedInput, key);
+        }
+    }
+
+    class MockJweAlgorithm : AesGcmEncryption, IJweAlgorithm
+    {
+        public MockJweAlgorithm(int keyLength) : base(keyLength) { }
+
+        public bool DecryptCalled { get; set; }
+        public bool EncryptCalled { get; set; }
+
+        public new byte[] Decrypt(byte[] aad, byte[] cek, byte[] iv, byte[] cipherText, byte[] authTag)
+        {
+            DecryptCalled = true;
+            return base.Decrypt(aad, cek, iv, cipherText, authTag);
+        }
+
+        public new byte[][] Encrypt(byte[] aad, byte[] plainText, byte[] cek)
+        {
+            EncryptCalled = true;
+            return base.Encrypt(aad, plainText, cek);
+        }
+    }
+
+    class MockKeyManagement : DirectKeyManagement, IKeyManagement
+    {
+        public bool UnwrapCalled { get; set; }
+        public bool WrapCalled { get; set; }
+
+        public new byte[] Unwrap(byte[] encryptedCek, object key, int cekSizeBits, IDictionary<string, object> header)
+        {
+            UnwrapCalled = true;
+            return base.Unwrap(encryptedCek, key, cekSizeBits, header);
+        }
+
+        public new byte[][] WrapNewKey(int cekSizeBits, object key, IDictionary<string, object> header)
+        {
+            WrapCalled = true;
+            return base.WrapNewKey(cekSizeBits, key, header);
+        }
+    }
+
+    class MockCompression : DeflateCompression, ICompression
+    {
+        public bool CompressCalled { get; set; }
+        public bool DecompressCalled { get; set; }
+
+        public new byte[] Compress(byte[] plainText)
+        {
+            CompressCalled = true;
+            return base.Compress(plainText);
+        }
+
+        public new byte[] Decompress(byte[] compressedText)
+        {
+            DecompressCalled = true;
+            return base.Decompress(compressedText);
+        }
+    }
+
+#endregion
 }

--- a/UnitTestsNet40/TestSuite.cs
+++ b/UnitTestsNet40/TestSuite.cs
@@ -7,6 +7,7 @@ using Jose;
 using Security.Cryptography;
 using NUnit.Framework;
 using System.Linq;
+using Jose.jwe;
 
 namespace UnitTests
 {
@@ -2485,6 +2486,228 @@ namespace UnitTests
             // then
             Assert.That(test, Is.EqualTo(new Dictionary<string, object> { { "hello", "world" } }));
         }
+        
+        [Fact]
+        public void Encode_IJsonMapper_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJsonMapper jsMapper = new MockJsonMapper();
+            settings.JsonMapper = jsMapper;
+            var payload = new
+            {
+                hello = "world"
+            };
+            //when
+            string token = Jose.JWT.Encode(payload, null, JwsAlgorithm.none, settings: settings);
+
+            Console.Out.WriteLine("Plaintext:" + token);
+
+            //then
+            Assert.Equal(token, "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJoZWxsbyI6IndvcmxkIn0.");
+            Assert.True(jsMapper.SerializeCalled);
+        }
+
+        [Fact]
+        public void Decode_IJsonMapper_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJsonMapper jsMapper = new MockJsonMapper();
+            settings.JsonMapper = jsMapper;
+            string token = "eyJhbGciOiJub25lIn0.eyJoZWxsbyI6ICJ3b3JsZCJ9.";
+
+            //when
+            var test = Jose.JWT.Decode<IDictionary<string, object>>(token, settings: settings);
+
+            //then
+            Assert.Equal(test, new Dictionary<string, object> { { "hello", "world" } });
+            Assert.True(jsMapper.ParseCalled);
+        }
+
+        [Fact]
+        public void Encode_IJwsAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJwsAlgorithm jwsAlg = new MockJwsAlgorithm();
+            settings.HashAlgorithms[JwsAlgorithm.none] = jwsAlg;
+            var payload = new
+            {
+                hello = "world"
+            };
+
+            //when
+            string token = Jose.JWT.Encode(payload, null, JwsAlgorithm.none, settings: settings);
+
+            Console.Out.WriteLine("Plaintext:" + token);
+
+            //then
+            Assert.Equal(token, "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJoZWxsbyI6IndvcmxkIn0.");
+            Assert.True(jwsAlg.SignCalled);
+        }
+
+        [Fact]
+        public void Decode_IJwsAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJwsAlgorithm jwsAlg = new MockJwsAlgorithm();
+            settings.HashAlgorithms[JwsAlgorithm.none] = jwsAlg;
+            string token = "eyJhbGciOiJub25lIn0.eyJoZWxsbyI6ICJ3b3JsZCJ9.";
+
+            //when
+            var test = Jose.JWT.Decode<IDictionary<string, object>>(token, settings: settings);
+
+            //then
+            Assert.Equal(test, new Dictionary<string, object> { { "hello", "world" } });
+            Assert.True(jwsAlg.VerifyCalled);
+        }
+
+        [Fact]
+        public void Encode_IJweAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJweAlgorithm encAlg = new MockJweAlgorithm(128);
+            settings.EncAlgorithms[JweEncryption.A128GCM] = encAlg;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, aes128Key, JweAlgorithm.DIR, JweEncryption.A128GCM, settings: settings);
+
+            //then
+            Console.Out.WriteLine("DIR_A128GCM = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 0); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[3].Length, 262); //cipher text size
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, aes128Key), json);
+            Assert.True(encAlg.EncryptCalled);
+        }
+
+        [Fact]
+        public void Decode_IJweAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJweAlgorithm encAlg = new MockJweAlgorithm(128);
+            settings.EncAlgorithms[JweEncryption.A128GCM] = encAlg;
+            string token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..yVi-LdQQngN0C5WS.1McwSmhZzAtmmLp9y-OdnJwaJFo1nj_4ashmzl2LhubGf0Jl1OTEVJzsHZb7bkup7cGTkuxh6Vfv10ljHsjWf_URXoxP3stQqQeViVcuPV0y2Q_WHYzTNGZpmHGe-hM6gjDhyZyvu3yeXGFSvfPQmp9pWVOgDjI4RC0MQ83rzzn-rRdnZkznWjbmOPxwPrR72Qng0BISsEwbkPn4oO8-vlHkVmPpuDTaYzCT2ZR5K9JnIU8d8QdxEAGb7-s8GEJ1yqtd_w._umbK59DAKA3O89h15VoKQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, aes128Key, settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392548520,""sub"":""alice"",""nbf"":1392547920,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""0e659a67-1cd3-438b-8888-217e72951ec9"",""iat"":1392547920}");
+            Assert.True(encAlg.DecryptCalled);
+        }
+
+        [Fact]
+        public void Encode_IKeyManagement_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockKeyManagement keyMgmt = new MockKeyManagement();
+            settings.KeyAlgorithms[JweAlgorithm.DIR] = keyMgmt;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, aes128Key, JweAlgorithm.DIR, JweEncryption.A128GCM, settings: settings);
+
+            //then
+            Console.Out.WriteLine("DIR_A128GCM = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 0); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[3].Length, 262); //cipher text size
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, aes128Key), json);
+
+            Assert.True(keyMgmt.WrapCalled);
+        }
+
+        [Fact]
+        public void Decode_IKeyManagement_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockKeyManagement keyMgmt = new MockKeyManagement();
+            settings.KeyAlgorithms[JweAlgorithm.DIR] = keyMgmt;
+            string token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..yVi-LdQQngN0C5WS.1McwSmhZzAtmmLp9y-OdnJwaJFo1nj_4ashmzl2LhubGf0Jl1OTEVJzsHZb7bkup7cGTkuxh6Vfv10ljHsjWf_URXoxP3stQqQeViVcuPV0y2Q_WHYzTNGZpmHGe-hM6gjDhyZyvu3yeXGFSvfPQmp9pWVOgDjI4RC0MQ83rzzn-rRdnZkznWjbmOPxwPrR72Qng0BISsEwbkPn4oO8-vlHkVmPpuDTaYzCT2ZR5K9JnIU8d8QdxEAGb7-s8GEJ1yqtd_w._umbK59DAKA3O89h15VoKQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, aes128Key, settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392548520,""sub"":""alice"",""nbf"":1392547920,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""0e659a67-1cd3-438b-8888-217e72951ec9"",""iat"":1392547920}");
+            Assert.True(keyMgmt.UnwrapCalled);
+        }
+
+        [Fact]
+        public void Encode_ICompression_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockCompression compress = new MockCompression();
+            settings.CompressionAlgorithms[JweCompression.DEF] = compress;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, PubKey(), JweAlgorithm.RSA_OAEP, JweEncryption.A256GCM, JweCompression.DEF, settings: settings);
+
+            //then
+            Console.Out.WriteLine("RSA-OAEP_A256GCM-DEFLATE = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00iLCJ6aXAiOiJERUYifQ"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 342); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, PrivKey()), json);
+
+            Assert.True(compress.CompressCalled);
+        }
+
+        [Fact]
+        public void Decode_ICompression_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockCompression compress = new MockCompression();
+            settings.CompressionAlgorithms[JweCompression.DEF] = compress;
+            string token = "eyJhbGciOiJSU0EtT0FFUCIsInppcCI6IkRFRiIsImVuYyI6IkExMjhDQkMtSFMyNTYifQ.nXSS9jDwE0dXkcGI7UquZBhn2nsB2P8u-YSWEuTAgEeuV54qNU4SlE76bToI1z4LUuABHmZOv9S24xkF45b7Mrap_Fu4JXH8euXrQgKQb9o_HL5FvE8m4zk5Ow13MKGPvHvWKOaNEBFriwYIfPi6QBYrpuqn0BaANc_aMyInV0Fn7e8EAgVmvoagmy7Hxic2sPUeLEIlRCDSGa82mpiGusjo7VMJxymkhnMdKufpGPh4wod7pvgb-jDWasUHpsUkHqSKZxlrDQxcy1-Pu1G37TAnImlWPa9NU7500IXc-W07IJccXhR3qhA5QaIyBbmHY0j1Dn3808oSFOYSF85A9w.uwbZhK-8iNzcjvKRb1a2Ig.jxj1GfH9Ndu1y0b7NRz_yfmjrvX2rXQczyK9ZJGWTWfeNPGR_PZdJmddiam15Qtz7R-pzIeyR4_qQoMzOISkq6fDEvEWVZdHnnTUHQzCoGX1dZoG9jXEwfAk2G1vXYT2vynEQZ72xk0V_OBtKhpIAUEFsXwCUeLAAgjFNY4OGWZl_Kmv9RTGhnePZfVbrbwg.WuV64jlV03OZm99qHMP9wQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, PrivKey(), settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392963710,""sub"":""alice"",""nbf"":1392963110,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""9fa7a38a-28fd-421c-825c-8fab3bbf3fb4"",""iat"":1392963110}");
+            Assert.True(compress.DecompressCalled);
+        }
 
         #region test utils
 
@@ -2563,5 +2786,100 @@ namespace UnitTests
 
         #endregion
     }
+    
+#region mocks
 
+    class MockJsonMapper : JSSerializerMapper, IJsonMapper
+    {
+        public bool SerializeCalled { get; set; }
+        public bool ParseCalled { get; set; }
+
+        public new string Serialize(object obj)
+        {
+            SerializeCalled = true;
+            return base.Serialize(obj);
+        }
+
+        public new T Parse<T>(string json)
+        {
+            ParseCalled = true;
+            return base.Parse<T>(json);
+        }
+    }
+
+    class MockJwsAlgorithm : Plaintext, IJwsAlgorithm
+    {
+        public bool SignCalled { get; set; }
+        public bool VerifyCalled { get; set; }
+
+        public new byte[] Sign(byte[] securedInput, object key)
+        {
+            SignCalled = true;
+            return base.Sign(securedInput, key);
+        }
+
+        public new bool Verify(byte[] signature, byte[] securedInput, object key)
+        {
+            VerifyCalled = true;
+            return base.Verify(signature, securedInput, key);
+        }
+    }
+
+    class MockJweAlgorithm : AesGcmEncryption, IJweAlgorithm
+    {
+        public MockJweAlgorithm(int keyLength) : base(keyLength) { }
+
+        public bool DecryptCalled { get; set; }
+        public bool EncryptCalled { get; set; }
+
+        public new byte[] Decrypt(byte[] aad, byte[] cek, byte[] iv, byte[] cipherText, byte[] authTag)
+        {
+            DecryptCalled = true;
+            return base.Decrypt(aad, cek, iv, cipherText, authTag);
+        }
+
+        public new byte[][] Encrypt(byte[] aad, byte[] plainText, byte[] cek)
+        {
+            EncryptCalled = true;
+            return base.Encrypt(aad, plainText, cek);
+        }
+    }
+
+    class MockKeyManagement : DirectKeyManagement, IKeyManagement
+    {
+        public bool UnwrapCalled { get; set; }
+        public bool WrapCalled { get; set; }
+
+        public new byte[] Unwrap(byte[] encryptedCek, object key, int cekSizeBits, IDictionary<string, object> header)
+        {
+            UnwrapCalled = true;
+            return base.Unwrap(encryptedCek, key, cekSizeBits, header);
+        }
+
+        public new byte[][] WrapNewKey(int cekSizeBits, object key, IDictionary<string, object> header)
+        {
+            WrapCalled = true;
+            return base.WrapNewKey(cekSizeBits, key, header);
+        }
+    }
+
+    class MockCompression : DeflateCompression, ICompression
+    {
+        public bool CompressCalled { get; set; }
+        public bool DecompressCalled { get; set; }
+
+        public new byte[] Compress(byte[] plainText)
+        {
+            CompressCalled = true;
+            return base.Compress(plainText);
+        }
+
+        public new byte[] Decompress(byte[] compressedText)
+        {
+            DecompressCalled = true;
+            return base.Decompress(compressedText);
+        }
+    }
+
+#endregion
 }

--- a/UnitTestsNet46/TestSuite.cs
+++ b/UnitTestsNet46/TestSuite.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Jose;
 using Security.Cryptography;
 using Xunit;
+using Jose.jwe;
 
 namespace UnitTests
 {
@@ -2590,6 +2591,228 @@ namespace UnitTests
             }
         }
 
+        [Fact]
+        public void Encode_IJsonMapper_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJsonMapper jsMapper = new MockJsonMapper();
+            settings.JsonMapper = jsMapper;
+            var payload = new
+            {
+                hello = "world"
+            };
+            //when
+            string token = Jose.JWT.Encode(payload, null, JwsAlgorithm.none, settings: settings);
+
+            Console.Out.WriteLine("Plaintext:" + token);
+
+            //then
+            Assert.Equal(token, "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJoZWxsbyI6IndvcmxkIn0.");
+            Assert.True(jsMapper.SerializeCalled);
+        }
+
+        [Fact]
+        public void Decode_IJsonMapper_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJsonMapper jsMapper = new MockJsonMapper();
+            settings.JsonMapper = jsMapper;
+            string token = "eyJhbGciOiJub25lIn0.eyJoZWxsbyI6ICJ3b3JsZCJ9.";
+
+            //when
+            var test = Jose.JWT.Decode<IDictionary<string, object>>(token, settings: settings);
+
+            //then
+            Assert.Equal(test, new Dictionary<string, object> { { "hello", "world" } });
+            Assert.True(jsMapper.ParseCalled);
+        }
+
+        [Fact]
+        public void Encode_IJwsAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJwsAlgorithm jwsAlg = new MockJwsAlgorithm();
+            settings.HashAlgorithms[JwsAlgorithm.none] = jwsAlg;
+            var payload = new
+            {
+                hello = "world"
+            };
+
+            //when
+            string token = Jose.JWT.Encode(payload, null, JwsAlgorithm.none, settings: settings);
+
+            Console.Out.WriteLine("Plaintext:" + token);
+
+            //then
+            Assert.Equal(token, "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJoZWxsbyI6IndvcmxkIn0.");
+            Assert.True(jwsAlg.SignCalled);
+        }
+
+        [Fact]
+        public void Decode_IJwsAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJwsAlgorithm jwsAlg = new MockJwsAlgorithm();
+            settings.HashAlgorithms[JwsAlgorithm.none] = jwsAlg;
+            string token = "eyJhbGciOiJub25lIn0.eyJoZWxsbyI6ICJ3b3JsZCJ9.";
+
+            //when
+            var test = Jose.JWT.Decode<IDictionary<string, object>>(token, settings: settings);
+
+            //then
+            Assert.Equal(test, new Dictionary<string, object> { { "hello", "world" } });
+            Assert.True(jwsAlg.VerifyCalled);
+        }
+
+        [Fact]
+        public void Encode_IJweAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJweAlgorithm encAlg = new MockJweAlgorithm(128);
+            settings.EncAlgorithms[JweEncryption.A128GCM] = encAlg;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, aes128Key, JweAlgorithm.DIR, JweEncryption.A128GCM, settings: settings);
+
+            //then
+            Console.Out.WriteLine("DIR_A128GCM = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 0); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[3].Length, 262); //cipher text size
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, aes128Key), json);
+            Assert.True(encAlg.EncryptCalled);
+        }
+
+        [Fact]
+        public void Decode_IJweAlgorithm_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockJweAlgorithm encAlg = new MockJweAlgorithm(128);
+            settings.EncAlgorithms[JweEncryption.A128GCM] = encAlg;
+            string token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..yVi-LdQQngN0C5WS.1McwSmhZzAtmmLp9y-OdnJwaJFo1nj_4ashmzl2LhubGf0Jl1OTEVJzsHZb7bkup7cGTkuxh6Vfv10ljHsjWf_URXoxP3stQqQeViVcuPV0y2Q_WHYzTNGZpmHGe-hM6gjDhyZyvu3yeXGFSvfPQmp9pWVOgDjI4RC0MQ83rzzn-rRdnZkznWjbmOPxwPrR72Qng0BISsEwbkPn4oO8-vlHkVmPpuDTaYzCT2ZR5K9JnIU8d8QdxEAGb7-s8GEJ1yqtd_w._umbK59DAKA3O89h15VoKQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, aes128Key, settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392548520,""sub"":""alice"",""nbf"":1392547920,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""0e659a67-1cd3-438b-8888-217e72951ec9"",""iat"":1392547920}");
+            Assert.True(encAlg.DecryptCalled);
+        }
+
+        [Fact]
+        public void Encode_IKeyManagement_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockKeyManagement keyMgmt = new MockKeyManagement();
+            settings.KeyAlgorithms[JweAlgorithm.DIR] = keyMgmt;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, aes128Key, JweAlgorithm.DIR, JweEncryption.A128GCM, settings: settings);
+
+            //then
+            Console.Out.WriteLine("DIR_A128GCM = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 0); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[3].Length, 262); //cipher text size
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, aes128Key), json);
+
+            Assert.True(keyMgmt.WrapCalled);
+        }
+
+        [Fact]
+        public void Decode_IKeyManagement_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockKeyManagement keyMgmt = new MockKeyManagement();
+            settings.KeyAlgorithms[JweAlgorithm.DIR] = keyMgmt;
+            string token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..yVi-LdQQngN0C5WS.1McwSmhZzAtmmLp9y-OdnJwaJFo1nj_4ashmzl2LhubGf0Jl1OTEVJzsHZb7bkup7cGTkuxh6Vfv10ljHsjWf_URXoxP3stQqQeViVcuPV0y2Q_WHYzTNGZpmHGe-hM6gjDhyZyvu3yeXGFSvfPQmp9pWVOgDjI4RC0MQ83rzzn-rRdnZkznWjbmOPxwPrR72Qng0BISsEwbkPn4oO8-vlHkVmPpuDTaYzCT2ZR5K9JnIU8d8QdxEAGb7-s8GEJ1yqtd_w._umbK59DAKA3O89h15VoKQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, aes128Key, settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392548520,""sub"":""alice"",""nbf"":1392547920,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""0e659a67-1cd3-438b-8888-217e72951ec9"",""iat"":1392547920}");
+            Assert.True(keyMgmt.UnwrapCalled);
+        }
+
+        [Fact]
+        public void Encode_ICompression_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockCompression compress = new MockCompression();
+            settings.CompressionAlgorithms[JweCompression.DEF] = compress;
+            string json =
+                @"{""exp"":1389189552,""sub"":""alice"",""nbf"":1389188952,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""e543edf6-edf0-4348-8940-c4e28614d463"",""iat"":1389188952}";
+
+            //when
+            string token = Jose.JWT.Encode(json, PubKey(), JweAlgorithm.RSA_OAEP, JweEncryption.A256GCM, JweCompression.DEF, settings: settings);
+
+            //then
+            Console.Out.WriteLine("RSA-OAEP_A256GCM-DEFLATE = {0}", token);
+
+            string[] parts = token.Split('.');
+
+            Assert.Equal(parts.Length, 5); //Make sure 5 parts
+            Assert.Equal(parts[0], "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00iLCJ6aXAiOiJERUYifQ"); //Header is non-encrypted and static text
+            Assert.Equal(parts[1].Length, 342); //CEK size
+            Assert.Equal(parts[2].Length, 16); //IV size, 96 bits
+            Assert.Equal(parts[4].Length, 22); //auth tag size
+
+            Assert.Equal(Jose.JWT.Decode(token, PrivKey()), json);
+
+            Assert.True(compress.CompressCalled);
+        }
+
+        [Fact]
+        public void Decode_ICompression_Override()
+        {
+            //given
+            JWTSettings settings = new JWTSettings();
+            MockCompression compress = new MockCompression();
+            settings.CompressionAlgorithms[JweCompression.DEF] = compress;
+            string token = "eyJhbGciOiJSU0EtT0FFUCIsInppcCI6IkRFRiIsImVuYyI6IkExMjhDQkMtSFMyNTYifQ.nXSS9jDwE0dXkcGI7UquZBhn2nsB2P8u-YSWEuTAgEeuV54qNU4SlE76bToI1z4LUuABHmZOv9S24xkF45b7Mrap_Fu4JXH8euXrQgKQb9o_HL5FvE8m4zk5Ow13MKGPvHvWKOaNEBFriwYIfPi6QBYrpuqn0BaANc_aMyInV0Fn7e8EAgVmvoagmy7Hxic2sPUeLEIlRCDSGa82mpiGusjo7VMJxymkhnMdKufpGPh4wod7pvgb-jDWasUHpsUkHqSKZxlrDQxcy1-Pu1G37TAnImlWPa9NU7500IXc-W07IJccXhR3qhA5QaIyBbmHY0j1Dn3808oSFOYSF85A9w.uwbZhK-8iNzcjvKRb1a2Ig.jxj1GfH9Ndu1y0b7NRz_yfmjrvX2rXQczyK9ZJGWTWfeNPGR_PZdJmddiam15Qtz7R-pzIeyR4_qQoMzOISkq6fDEvEWVZdHnnTUHQzCoGX1dZoG9jXEwfAk2G1vXYT2vynEQZ72xk0V_OBtKhpIAUEFsXwCUeLAAgjFNY4OGWZl_Kmv9RTGhnePZfVbrbwg.WuV64jlV03OZm99qHMP9wQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, PrivKey(), settings: settings);
+
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""exp"":1392963710,""sub"":""alice"",""nbf"":1392963110,""aud"":[""https:\/\/app-one.com"",""https:\/\/app-two.com""],""iss"":""https:\/\/openid.net"",""jti"":""9fa7a38a-28fd-421c-825c-8fab3bbf3fb4"",""iat"":1392963110}");
+            Assert.True(compress.DecompressCalled);
+        }
+
         #region test utils
 
         private RSACryptoServiceProvider PrivKey()
@@ -2692,4 +2915,99 @@ namespace UnitTests
         #endregion
     }
 
+    #region mocks
+
+    class MockJsonMapper : JSSerializerMapper, IJsonMapper
+    {
+        public bool SerializeCalled { get; set; }
+        public bool ParseCalled { get; set; }
+
+        public new string Serialize(object obj)
+        {
+            SerializeCalled = true;
+            return base.Serialize(obj);
+        }
+
+        public new T Parse<T>(string json)
+        {
+            ParseCalled = true;
+            return base.Parse<T>(json);
+        }
+    }
+
+    class MockJwsAlgorithm : Plaintext, IJwsAlgorithm
+    {
+        public bool SignCalled { get; set; }
+        public bool VerifyCalled { get; set; }
+
+        public new byte[] Sign(byte[] securedInput, object key)
+        {
+            SignCalled = true;
+            return base.Sign(securedInput, key);
+        }
+
+        public new bool Verify(byte[] signature, byte[] securedInput, object key)
+        {
+            VerifyCalled = true;
+            return base.Verify(signature, securedInput, key);
+        }
+    }
+
+    class MockJweAlgorithm : AesGcmEncryption, IJweAlgorithm
+    {
+        public MockJweAlgorithm(int keyLength) : base(keyLength) { }
+
+        public bool DecryptCalled { get; set; }
+        public bool EncryptCalled { get; set; }
+
+        public new byte[] Decrypt(byte[] aad, byte[] cek, byte[] iv, byte[] cipherText, byte[] authTag)
+        {
+            DecryptCalled = true;
+            return base.Decrypt(aad, cek, iv, cipherText, authTag);
+        }
+
+        public new byte[][] Encrypt(byte[] aad, byte[] plainText, byte[] cek)
+        {
+            EncryptCalled = true;
+            return base.Encrypt(aad, plainText, cek);
+        }
+    }
+
+    class MockKeyManagement : DirectKeyManagement, IKeyManagement
+    {
+        public bool UnwrapCalled { get; set; }
+        public bool WrapCalled { get; set; }
+
+        public new byte[] Unwrap(byte[] encryptedCek, object key, int cekSizeBits, IDictionary<string, object> header)
+        {
+            UnwrapCalled = true;
+            return base.Unwrap(encryptedCek, key, cekSizeBits, header);
+        }
+
+        public new byte[][] WrapNewKey(int cekSizeBits, object key, IDictionary<string, object> header)
+        {
+            WrapCalled = true;
+            return base.WrapNewKey(cekSizeBits, key, header);
+        }
+    }
+
+    class MockCompression : DeflateCompression, ICompression
+    {
+        public bool CompressCalled { get; set; }
+        public bool DecompressCalled { get; set; }
+
+        public new byte[] Compress(byte[] plainText)
+        {
+            CompressCalled = true;
+            return base.Compress(plainText);
+        }
+
+        public new byte[] Decompress(byte[] compressedText)
+        {
+            DecompressCalled = true;
+            return base.Decompress(compressedText);
+        }
+    }
+
+#endregion
 }

--- a/jose-jwt/JWTSettings.cs
+++ b/jose-jwt/JWTSettings.cs
@@ -1,0 +1,110 @@
+﻿using Jose.jwe;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Jose
+{
+    /// <summary>
+    /// JWT settings object.  JWT has a global DefaultSettings instance that can be used to set global defaults.  Additionally,
+    /// every method in JWT supports adding an optional settings parameter to override the default settings just for that call.
+    /// </summary>
+    public class JWTSettings
+    {
+        private Dictionary<JwsAlgorithm, IJwsAlgorithm> hashAlgorithms = new Dictionary<JwsAlgorithm, IJwsAlgorithm>
+            {
+                { JwsAlgorithm.none, new Plaintext()},
+                { JwsAlgorithm.HS256, new HmacUsingSha("SHA256") },
+                { JwsAlgorithm.HS384, new HmacUsingSha("SHA384") },
+                { JwsAlgorithm.HS512, new HmacUsingSha("SHA512") },
+
+                { JwsAlgorithm.RS256, new RsaUsingSha("SHA256") },
+                { JwsAlgorithm.RS384, new RsaUsingSha("SHA384") },
+                { JwsAlgorithm.RS512, new RsaUsingSha("SHA512") },
+
+                { JwsAlgorithm.PS256, new RsaPssUsingSha(32) },
+                { JwsAlgorithm.PS384, new RsaPssUsingSha(48) },
+                { JwsAlgorithm.PS512, new RsaPssUsingSha(64) },
+#if NET40
+                { JwsAlgorithm.ES256, new EcdsaUsingSha(256) },
+                { JwsAlgorithm.ES384, new EcdsaUsingSha(384) },
+                { JwsAlgorithm.ES512, new EcdsaUsingSha(521) }
+#elif NETSTANDARD1_4 || NET461
+                { JwsAlgorithm.ES256, new Jose.netstandard1_4.EcdsaUsingSha(256) },
+                { JwsAlgorithm.ES384, new Jose.netstandard1_4.EcdsaUsingSha(384) },
+                { JwsAlgorithm.ES512, new Jose.netstandard1_4.EcdsaUsingSha(521) }
+#endif
+            };
+
+        private Dictionary<JweEncryption, IJweAlgorithm> encAlgorithms = new Dictionary<JweEncryption, IJweAlgorithm>
+            {
+                { JweEncryption.A128CBC_HS256, new AesCbcHmacEncryption(new HmacUsingSha("SHA256"), 256) },
+                { JweEncryption.A192CBC_HS384, new AesCbcHmacEncryption(new HmacUsingSha("SHA384"), 384) },
+                { JweEncryption.A256CBC_HS512, new AesCbcHmacEncryption(new HmacUsingSha("SHA512"), 512) },
+
+                { JweEncryption.A128GCM, new AesGcmEncryption(128) },
+                { JweEncryption.A192GCM, new AesGcmEncryption(192) },
+                { JweEncryption.A256GCM, new AesGcmEncryption(256) }
+            };
+
+        private Dictionary<JweAlgorithm, IKeyManagement> keyAlgorithms = new Dictionary<JweAlgorithm, IKeyManagement>
+            {
+                { JweAlgorithm.RSA_OAEP, new RsaKeyManagement(true) },
+                { JweAlgorithm.RSA_OAEP_256, new RsaOaep256KeyManagement() },
+                { JweAlgorithm.RSA1_5, new RsaKeyManagement(false) },
+                { JweAlgorithm.DIR, new DirectKeyManagement() },
+                { JweAlgorithm.A128KW, new AesKeyWrapManagement(128) },
+                { JweAlgorithm.A192KW, new AesKeyWrapManagement(192) },
+                { JweAlgorithm.A256KW, new AesKeyWrapManagement(256) },
+                { JweAlgorithm.ECDH_ES, new EcdhKeyManagement(true) },
+                { JweAlgorithm.ECDH_ES_A128KW, new EcdhKeyManagementWithAesKeyWrap(128, new AesKeyWrapManagement(128)) },
+                { JweAlgorithm.ECDH_ES_A192KW, new EcdhKeyManagementWithAesKeyWrap(192, new AesKeyWrapManagement(192)) },
+                { JweAlgorithm.ECDH_ES_A256KW, new EcdhKeyManagementWithAesKeyWrap(256, new AesKeyWrapManagement(256)) },
+                { JweAlgorithm.PBES2_HS256_A128KW, new Pbse2HmacShaKeyManagementWithAesKeyWrap(128, new AesKeyWrapManagement(128)) },
+                { JweAlgorithm.PBES2_HS384_A192KW, new Pbse2HmacShaKeyManagementWithAesKeyWrap(192, new AesKeyWrapManagement(192)) },
+                { JweAlgorithm.PBES2_HS512_A256KW, new Pbse2HmacShaKeyManagementWithAesKeyWrap(256, new AesKeyWrapManagement(256)) },
+                { JweAlgorithm.A128GCMKW, new AesGcmKeyWrapManagement(128) },
+                { JweAlgorithm.A192GCMKW, new AesGcmKeyWrapManagement(192) },
+                { JweAlgorithm.A256GCMKW, new AesGcmKeyWrapManagement(256) }
+            };
+
+        private Dictionary<JweCompression, ICompression> compressionAlgorithms = new Dictionary<JweCompression, ICompression>
+            {
+                { JweCompression.DEF, new DeflateCompression() }
+            };
+
+#if NET40 || NET461
+        private IJsonMapper jsMapper = new JSSerializerMapper();
+#elif NETSTANDARD1_4
+        private IJsonMapper jsMapper = new NewtonsoftMapper();
+#endif
+
+
+        public Dictionary<JwsAlgorithm, IJwsAlgorithm> HashAlgorithms
+        {
+            get { return hashAlgorithms; }
+        }
+
+        public Dictionary<JweEncryption, IJweAlgorithm> EncAlgorithms
+        {
+            get { return encAlgorithms; }
+        }
+
+        public Dictionary<JweAlgorithm, IKeyManagement> KeyAlgorithms
+        {
+            get { return keyAlgorithms; }
+        }
+
+        public Dictionary<JweCompression, ICompression> CompressionAlgorithms
+        {
+            get { return compressionAlgorithms; }
+        }
+
+        public IJsonMapper JsonMapper
+        {
+            get { return jsMapper; }
+            set { jsMapper = value; }
+        }
+    }
+}

--- a/jose-jwt/jose-jwt.net40.csproj
+++ b/jose-jwt/jose-jwt.net40.csproj
@@ -70,6 +70,7 @@
     <Compile Include="jws\RsaPssUsingSha.cs" />
     <Compile Include="jws\RsaUsingSha.cs" />
     <Compile Include="JWT.cs" />
+    <Compile Include="JWTSettings.cs" />
     <Compile Include="native\BCrypt.cs" />
     <Compile Include="native\NCrypt.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/jose-jwt/jose-jwt.net46.csproj
+++ b/jose-jwt/jose-jwt.net46.csproj
@@ -72,6 +72,7 @@
     <Compile Include="jws\RsaPssUsingSha.cs" />
     <Compile Include="jws\RsaUsingSha.cs" />
     <Compile Include="JWT.cs" />
+    <Compile Include="JWTSettings.cs" />
     <Compile Include="native\BCrypt.cs" />
     <Compile Include="native\NCrypt.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
When using a key management service, like [Azure KeyVault](https://azure.microsoft.com/en-us/services/key-vault/) or [Amazon KMS](https://aws.amazon.com/kms/) there is typically not a way to retrieve a private key once it has been created.  Instead you are expected to call an API to encrypt or decrypt data.

In order to use one of these then with jose-jwt, there'd need to be a way to specify a custom IKeyManagement implementation when encoding or decoding a token.  This lets the key wrapping/unwrapping be delegated to the external service instead of using the built in implementation for the given algorithm.