### PR TITLE
feat: support alias for 'alg' and 'enc' header values

### DIFF
--- a/UnitTestsNet46/SettingsTest.cs
+++ b/UnitTestsNet46/SettingsTest.cs
@@ -204,6 +204,47 @@ namespace UnitTests
             Assert.True(compress.DecompressCalled);
         }
 
+        [Fact]
+        public void Decode_JwsAlgorithm_Alias()
+        {
+            string token = "eyJhbGciOiJOT05FLUFMSUFTIn0.eyJoZWxsbyI6ICJ3b3JsZCJ9.";
+
+            var test = Jose.JWT.Decode<IDictionary<string, object>>(token, settings: new JwtSettings().RegisterJwsAlias("NONE-ALIAS", JwsAlgorithm.none));
+
+            Assert.Equal(test, new Dictionary<string, object> { { "hello", "world" } });
+        }
+
+        [Fact]
+        public void Decode_JweAlgorithm_Alias()
+        {
+            //given
+            string token = "eyJhbGciOiJSU0ExXzVfQUxJQVMiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.dMCd2RbBtGBb9QwpJ0lYbJ0zv5Nagl5SPwRhrJTlXTDWJ6s-Ztz0-SEOi_gXx0SxXGA2iy5gY3x2uWbi-TSZvBuNyATYqoHlPLTCvNW47_INL8Gw46VcNu54urKadPh01Agk9WajBBlx9fnGgQMw5F9YNZbo8LfUNbGnZDYaxB3Vbyhn1Q9j3X8cT2MfzQ0uEhqr4FTx12oCd-6rZXXHhGnfdOKJGaihGLf10JVJcGXwBVY4AghEcAsii0JJrk35kLjBnzfsjlb2pB1r7k_tI6_1g06-5ubz_oEtlwGBM9OeqYnTk66A4a8vUSzqEC9e3bEQbWwz94Qv2qO5r9dy5Q.Axsj29AR41DivbI_MwHVtg.OMQpAiDkqJsZo53bSz9XmKwzqnLBqI7MR7mp0NazAqI.V_t4NP94yJyKAUmeTgrysQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, PrivKey(), settings: new JwtSettings().RegisterJwaAlias("RSA1_5_ALIAS", JweAlgorithm.RSA1_5));
+            
+            //then
+            Console.Out.WriteLine("json = {0}", json);
+
+            Assert.Equal(json, @"{""hello"":""world""}");
+        }
+
+        [Fact]
+        public void Decode_JweEncryption_Alias()
+        {
+            //given
+            string token = "eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2X0FMSUFTIn0.O1GahcMJNBaTEgPeOPzjm-FistaXkzmdZMPB0YkJoI6X1KIc43HJjLH28njXLQ-mGKblEhJwyFar4yfyrV9bzRSxe9K7RNDuG31m83D9yo-A2Mx1FZtvSUwm5yT62Xk0-BuZOq6S3algXvgTQie1MGRuSED-a6xmRj5RcEpop5JdEXnnlwCrn4qZt9jQpT_Ag_URgkNyuBJG878MXjArxU9Ci5WS1a-tcOgCtd33JOiCvniIBQBPFdyoz7vGZi3Y7EGhY-6T6dxyeL-_MMbkl_60HlTPrd6exfZ3c_0ofwSgvua_gAdSEN4inJWxJjH2yXiR0Ylj_lXAq_la3xFAhA.R2kyFSctYUZgIYJrUTWl8Q.LS4PGAa0bE-OyshBxUh5XhFvquKffEsSmEVU_LxSRAQ.hDDEkppjnfWUv_jKUcA6DQ";
+
+            //when
+            string json = Jose.JWT.Decode(token, PrivKey(), settings: new JwtSettings().RegisterJweAlias("A128CBC-HS256_ALIAS", JweEncryption.A128CBC_HS256));
+
+            //then
+            Console.Out.WriteLine("json = {0}", token);
+
+            Assert.Equal(json, @"{""hello"":""world""}");
+        }
+
+
         #region test utils
 
         private RSACryptoServiceProvider PrivKey()

--- a/jose-jwt/JWTSettings.cs
+++ b/jose-jwt/JWTSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Jose.jwe;
 using System.Collections.Generic;
+using System;
 
 namespace Jose
 {
@@ -34,6 +35,25 @@ namespace Jose
 #endif
             };
 
+        private Dictionary<JwsAlgorithm, string> jwsAlgorithmsHeaderValue = new Dictionary<JwsAlgorithm, string>
+            {
+                { JwsAlgorithm.none, "none" },
+                { JwsAlgorithm.HS256, "HS256" },
+                { JwsAlgorithm.HS384, "HS384" },
+                { JwsAlgorithm.HS512, "HS512" },
+                { JwsAlgorithm.RS256, "RS256" },
+                { JwsAlgorithm.RS384, "RS384" },
+                { JwsAlgorithm.RS512, "RS512" },
+                { JwsAlgorithm.ES256, "ES256" },
+                { JwsAlgorithm.ES384, "ES384" },
+                { JwsAlgorithm.ES512, "ES512" },
+                { JwsAlgorithm.PS256, "PS256" },
+                { JwsAlgorithm.PS384, "PS384" },
+                { JwsAlgorithm.PS512, "PS512" },
+            };
+
+        private Dictionary<string, JwsAlgorithm> jwsAlgorithmsAliases = new Dictionary<string, JwsAlgorithm>();
+
         private Dictionary<JweEncryption, IJweAlgorithm> encAlgorithms = new Dictionary<JweEncryption, IJweAlgorithm>
             {
                 { JweEncryption.A128CBC_HS256, new AesCbcHmacEncryption(new HmacUsingSha("SHA256"), 256) },
@@ -44,6 +64,18 @@ namespace Jose
                 { JweEncryption.A192GCM, new AesGcmEncryption(192) },
                 { JweEncryption.A256GCM, new AesGcmEncryption(256) }
             };
+
+        private Dictionary<JweEncryption, string> encAlgorithmsHeaderValue = new Dictionary<JweEncryption, string>
+            {
+                { JweEncryption.A128CBC_HS256, "A128CBC-HS256" },
+                { JweEncryption.A192CBC_HS384, "A192CBC-HS384" },
+                { JweEncryption.A256CBC_HS512, "A256CBC-HS512" },
+                { JweEncryption.A128GCM, "A128GCM" },
+                { JweEncryption.A192GCM, "A192GCM" },
+                { JweEncryption.A256GCM, "A256GCM" },
+            };
+
+        private Dictionary<string, JweEncryption> encAlgorithmsAliases = new Dictionary<string, JweEncryption>();
 
         private Dictionary<JweAlgorithm, IKeyManagement> keyAlgorithms = new Dictionary<JweAlgorithm, IKeyManagement>
             {
@@ -65,6 +97,28 @@ namespace Jose
                 { JweAlgorithm.A192GCMKW, new AesGcmKeyWrapManagement(192) },
                 { JweAlgorithm.A256GCMKW, new AesGcmKeyWrapManagement(256) }
             };
+        private Dictionary<JweAlgorithm, string> keyAlgorithmsHeaderValue = new Dictionary<JweAlgorithm, string>
+            {
+                { JweAlgorithm.RSA1_5, "RSA1_5" },
+                { JweAlgorithm.RSA_OAEP, "RSA-OAEP" },
+                { JweAlgorithm.RSA_OAEP_256, "RSA-OAEP-256" },
+                { JweAlgorithm.DIR, "dir" },
+                { JweAlgorithm.A128KW, "A128KW" },
+                { JweAlgorithm.A256KW, "A256KW" },
+                { JweAlgorithm.A192KW, "A192KW" },
+                { JweAlgorithm.ECDH_ES, "ECDH-ES" },
+                { JweAlgorithm.ECDH_ES_A128KW, "ECDH-ES+A128KW" },
+                { JweAlgorithm.ECDH_ES_A192KW, "ECDH-ES+A192KW" },
+                { JweAlgorithm.ECDH_ES_A256KW, "ECDH-ES+A256KW" },
+                { JweAlgorithm.PBES2_HS256_A128KW, "PBES2-HS256+A128KW" },
+                { JweAlgorithm.PBES2_HS384_A192KW, "PBES2-HS384+A192KW" },
+                { JweAlgorithm.PBES2_HS512_A256KW, "PBES2-HS512+A256KW" },
+                { JweAlgorithm.A128GCMKW, "A128GCMKW" },
+                { JweAlgorithm.A192GCMKW, "A192GCMKW" },
+                { JweAlgorithm.A256GCMKW, "A256GCMKW" },
+            };
+
+        private Dictionary<string, JweAlgorithm> keyAlgorithmsAliases = new Dictionary<string, JweAlgorithm>();
 
         private Dictionary<JweCompression, ICompression> compressionAlgorithms = new Dictionary<JweCompression, ICompression>
             {
@@ -83,10 +137,27 @@ namespace Jose
             keyAlgorithms[alg] = impl;
             return this;
         }
+        /// <summary>
+        /// Register an alias for the "alg" header that should point to a standard JWA key management algorithm
+        /// </summary>
+        public JwtSettings RegisterJwaAlias(string alias, JweAlgorithm alg)
+        {
+            keyAlgorithmsAliases[alias] = alg;
+            return this;
+        }
 
         public JwtSettings RegisterJwe(JweEncryption alg, IJweAlgorithm impl)
         {
             encAlgorithms[alg] = impl;
+            return this;
+        }
+
+        /// <summary>
+        /// Register an alias for the "enc" header that should point to a standard JWE encryption algorithm
+        /// </summary>
+        public JwtSettings RegisterJweAlias(string alias, JweEncryption alg)
+        {
+            encAlgorithmsAliases[alias] = alg;
             return this;
         }
 
@@ -100,6 +171,15 @@ namespace Jose
         {
             jwsAlgorithms[alg] = impl;
 
+            return this;
+        }
+        
+        /// <summary>
+        /// Register an alias for the "alg" header that should point to a standard JWS signing algorithm
+        /// </summary>
+        public JwtSettings RegisterJwsAlias(string alias, JwsAlgorithm alg)
+        {
+            jwsAlgorithmsAliases[alias] = alg;
             return this;
         }
 
@@ -124,6 +204,25 @@ namespace Jose
             return jwsAlgorithms.TryGetValue(alg, out impl) ? impl : null;
         }
 
+        public string JwsHeaderValue(JwsAlgorithm algorithm)
+        {
+            return jwsAlgorithmsHeaderValue[algorithm];
+        }
+
+        public JwsAlgorithm JwsAlgorithmFromHeader(string headerValue)
+        {
+            foreach (var pair in jwsAlgorithmsHeaderValue)
+            {
+                if (pair.Value.Equals(headerValue)) return pair.Key;
+            }
+            JwsAlgorithm aliasMatch;
+            if (jwsAlgorithmsAliases.TryGetValue(headerValue, out aliasMatch))
+            {
+                return aliasMatch;
+            }
+            throw new InvalidAlgorithmException(string.Format("JWS algorithm is not supported: {0}", headerValue));
+        }
+
         public ICompression Compression(JweCompression alg)
         {
             ICompression impl;
@@ -136,10 +235,50 @@ namespace Jose
             return encAlgorithms.TryGetValue(alg, out impl) ? impl : null; ;
         }
 
+        public string JweHeaderValue(JweEncryption algorithm)
+        {
+            return encAlgorithmsHeaderValue[algorithm];
+        }
+
+        public JweEncryption JweAlgorithmFromHeader(string headerValue)
+        {
+            foreach (var pair in encAlgorithmsHeaderValue)
+            {
+                if (pair.Value.Equals(headerValue)) return pair.Key;
+            }
+            JweEncryption aliasMatch;
+            if (encAlgorithmsAliases.TryGetValue(headerValue, out aliasMatch))
+            {
+                return aliasMatch;
+            }
+            throw new InvalidAlgorithmException(string.Format("JWE algorithm is not supported: {0}", headerValue));
+        }
+
         public IKeyManagement Jwa(JweAlgorithm alg)
         {
             IKeyManagement impl;
             return keyAlgorithms.TryGetValue(alg, out impl) ? impl : null;
         }
+
+        public string JwaHeaderValue(JweAlgorithm alg)
+        {
+            return keyAlgorithmsHeaderValue[alg];
+        }
+
+        public JweAlgorithm JwaAlgorithmFromHeader(string headerValue)
+        {
+            foreach (var pair in keyAlgorithmsHeaderValue)
+            {
+                if (pair.Value.Equals(headerValue)) return pair.Key;
+            }
+            JweAlgorithm aliasMatch;
+            if (keyAlgorithmsAliases.TryGetValue(headerValue, out aliasMatch))
+            {
+                return aliasMatch;
+            }
+            throw new InvalidAlgorithmException(string.Format("JWA algorithm is not supported: {0}.", headerValue));
+        }
+
+
     }
 }


### PR DESCRIPTION
This allows decoding of tokens that are not exactly compliant with the
specifications.

Fix for #63 