### PR TITLE
Make ConstantTimeEquals have no loop conditions

### DIFF
--- a/jose-jwt/util/Arrays.cs
+++ b/jose-jwt/util/Arrays.cs
@@ -114,13 +114,11 @@ namespace Jose
             if (expected.Length != actual.Length) 
                 return false;
 
-            bool equals = true;
-
+            byte result = 0;
             for (int i = 0; i < expected.Length; i++)
-                if (expected[i] != actual[i])
-                    equals = false;
+                result |= (byte)(expected[i] ^ actual[i]);
 
-            return equals;
+            return result == 0;
         }
 
         public static string Dump(byte[] arr, string label = "")


### PR DESCRIPTION
Currently Arrays.ConstantTimeEquals isn't truly constant-time. Every time a value between the expected and actual byte mismatch there are two additional instructions executed. For the current implementation the following IL code is generated for the loop:

	IL_003b:  ldarg.0 
	IL_003c:  ldloc.s 5
	IL_003e:  ldelem.u1 
	IL_003f:  ldarg.1 
	IL_0040:  ldloc.s 5
	IL_0042:  ldelem.u1 
	IL_0043:  ceq 
	IL_0045:  ldc.i4.0 
	IL_0046:  ceq 
	IL_0048:  stloc.s 6
	IL_004a:  ldloc.s 6
	IL_004c:  brfalse.s IL_0050 # byte compare here

	IL_004e:  ldc.i4.0  # this
	IL_004f:  stloc.0  # and this execute when bytes don't match
	IL_0050:  ldloc.s 5
	IL_0052:  ldc.i4.1 
	IL_0053:  add 
	IL_0054:  stloc.s 5
	IL_0056:  ldloc.s 5
	IL_0058:  ldarg.0 
	IL_0059:  ldlen 
	IL_005a:  conv.i4 
	IL_005b:  clt 
	IL_005d:  stloc.s 7
	IL_005f:  ldloc.s 7
	IL_0061:  brtrue.s IL_003b

Here's the IL code generated for an OR/XOR loop:


	IL_003b:  ldloc.0 
	IL_003c:  ldarg.0 
	IL_003d:  ldloc.s 5
	IL_003f:  ldelem.u1 
	IL_0040:  ldarg.1 
	IL_0041:  ldloc.s 5
	IL_0043:  ldelem.u1 
	IL_0044:  xor 
	IL_0045:  conv.u1 
	IL_0046:  or 
	IL_0047:  conv.u1 
	IL_0048:  stloc.0 
	IL_0049:  ldloc.s 5
	IL_004b:  ldc.i4.1 
	IL_004c:  add 
	IL_004d:  stloc.s 5
	IL_004f:  ldloc.s 5
	IL_0051:  ldarg.0 
	IL_0052:  ldlen 
	IL_0053:  conv.i4 
	IL_0054:  clt 
	IL_0056:  stloc.s 6
	IL_0058:  ldloc.s 6
	IL_005a:  brtrue.s IL_003b

There are no conditions based off the byte values. Therefore the same amount of instructions will execute per iteration which won't leak timing info.