### PR TITLE
Compact.Serialize alters the original token

### DIFF
--- a/jose-jwt/JWT.cs
+++ b/jose-jwt/JWT.cs
@@ -502,8 +502,14 @@ namespace Jose
                 byte[] header = parts[0];
                 byte[] payload = parts[1];
                 byte[] signature = parts[2];
+                string[] jwtSections = token.Split('.');
 
-                byte[] securedInput = Encoding.UTF8.GetBytes(Compact.Serialize(header, payload));
+                StringBuilder originalToken = new StringBuilder();
+                originalToken.Append(jwtSections[0]);
+                originalToken.Append(".");
+                originalToken.Append(jwtSections[1]);
+
+                byte[] securedInput = Encoding.UTF8.GetBytes(originalToken.ToString());
 
                 var jwtSettings = GetSettings(settings);
 


### PR DESCRIPTION
Compact.Serialize() reconstitutes the header.payload, but if the original was padded this step does not include the padding. This means when you get to the `if (!jwsAlgorithmImpl.Verify(signature, securedInput, key)){}` step then the verification fails; not because it's invalid but because the token being verified isn't the same token passed to the method.