### PR TITLE
Updating assembly version in Assemblyinfo.cs

### DIFF
--- a/jose-jwt/Properties/AssemblyInfo.cs
+++ b/jose-jwt/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("dvsekhvalnov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.5.0.0")]
+[assembly: AssemblyFileVersion("2.5.0.0")]


### PR DESCRIPTION
Updating the assembly version to 2.5.0.0 to reflect what's actually out in the wild - if the nuget package can't be amended it may be worth revving to 2.5.1.0 instead.