### PR TITLE
Use System.Text.Json for .NET Standard 2.1

### DIFF
--- a/UnitTests/SettingsTest.cs
+++ b/UnitTests/SettingsTest.cs
@@ -277,7 +277,7 @@ namespace UnitTests
 
         class MockJsonMapper
 #if NETCOREAPP
-            : NewtonsoftMapper,
+            : JsonMapper,
 #elif NET40 || NET461
             : JSSerializerMapper,
 #endif

--- a/jose-jwt/JWTSettings.cs
+++ b/jose-jwt/JWTSettings.cs
@@ -132,9 +132,11 @@ namespace Jose
         private Dictionary<string, JweCompression> compressionAlgorithmsAliases = new Dictionary<string, JweCompression>();
 
 #if NET40 || NET461
-        private IJsonMapper jsMapper = new JSSerializerMapper();                
-#elif NETSTANDARD
+        private IJsonMapper jsMapper = new JSSerializerMapper();
+#elif NETSTANDARD1_4
         private IJsonMapper jsMapper = new NewtonsoftMapper();
+#elif NETSTANDARD2_1
+        private IJsonMapper jsMapper = new JsonMapper();
 #endif
 
         //Builder-style methods

--- a/jose-jwt/jose-jwt.csproj
+++ b/jose-jwt/jose-jwt.csproj
@@ -116,7 +116,7 @@ RFC 7516:
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
 </Project>

--- a/jose-jwt/json/JsonMapper.cs
+++ b/jose-jwt/json/JsonMapper.cs
@@ -1,0 +1,108 @@
+﻿#if NETSTANDARD2_1
+using System;
+using System.Collections.Generic;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Unicode;
+
+namespace Jose
+{
+    public class JsonMapper : IJsonMapper
+    {
+        private readonly JsonSerializerOptions SerializeOptions;
+        private readonly JsonSerializerOptions DeserializeOptions;
+
+        public JsonMapper()
+        {
+            SerializeOptions = new JsonSerializerOptions
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            };
+
+            DeserializeOptions = new JsonSerializerOptions();
+            DeserializeOptions.Converters.Add(new NestedDictionariesConverter());
+        }
+
+        public string Serialize(object obj)
+        {
+            var json = JsonSerializer.Serialize(obj, SerializeOptions);
+            return json;
+        }
+
+        public T Parse<T>(string json)
+        {
+            if (String.IsNullOrEmpty(json))
+            {
+                return default(T);
+            }
+
+            Type objectType = typeof(T);
+
+            if (objectType == typeof(IDictionary<string, object>))
+            {
+                return JsonSerializer.Deserialize<T>(json, DeserializeOptions);
+            }
+
+            return JsonSerializer.Deserialize<T>(json);
+        }
+    }
+
+    class NestedDictionariesConverter : JsonConverter<object>
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            // in addition to handling IDictionary<string, object>
+            // we want to handle the deserialization of dict value
+            // which is of type object
+            return objectType == typeof(object) || base.CanConvert(objectType);
+        }
+
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                return reader.GetInt64();
+            }
+
+            if (reader.TokenType == JsonTokenType.True)
+            {
+                return true;
+            }
+
+            if (reader.TokenType == JsonTokenType.False)
+            {
+                return false;
+            }
+
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            var type = typeToConvert;
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                type = typeof(IDictionary<string, object>);
+            }
+            else if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                type = typeof(IEnumerable<object>);
+            }
+
+            return JsonSerializer.Deserialize(ref reader, type, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, typeof(object), options);
+        }
+    }
+}
+#endif

--- a/jose-jwt/json/NewtonsoftMapper.cs
+++ b/jose-jwt/json/NewtonsoftMapper.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if NETSTANDARD1_4
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;


### PR DESCRIPTION
This is an attempt to replace Newtonsoft.Json with System.Text.Json. Please consider this a starting point (at best) or simply some inspiration to remove the one last non-CoreFx dependency.

You will want to evaluate every line of `JsonMapper.cs` (particularly the use of `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`).

Fixes #130