### PR TITLE
Use PackageLicenseExpression instead of PackageLicenseFile

### DIFF
--- a/jose-jwt/jose-jwt.csproj
+++ b/jose-jwt/jose-jwt.csproj
@@ -53,7 +53,7 @@ JSON Web Key (RFC 7517):
     <PackageTags>jose;jwt;json;jwa;jwe;jws;jwk;aes;cbc;gcm;rsa;hmac;sha;rsassa;pss;rsaes;oaep;pkcs1-v1_5;es;elliptic;curve;diffe;hellman;agreement;ecdsa;key wrap;kw;ecdh;pbes;pbes2;pbkdf;pbkdf2;password based encryption;javascript object signing;two phase validation;netcore;clr;coreclr;portable;fips;compliant;open;banking;detached content;unencoded payload;json web key;</PackageTags>
     <PackageReleaseNotes>Major upgrade introducing cross platform ECDH compatibility for P-384 and P-521 NIST Curves on Windows, Linux, Mac OS and FreeBSD. Bugfixes and more security controls to address new threats.</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/dvsekhvalnov/jose-jwt</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
To make it easier for SBOM tools to detect the license used by this package.